### PR TITLE
Allow single-digit exponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ implementation in C++, [https://github.com/vitaut/zmij][upstream].
 fn main() {
     let mut buffer = zmij::Buffer::new();
     let printed = buffer.format(1.234);
-    assert_eq!(printed, "1.234e+00");
+    assert_eq!(printed, "1.234e+0");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,17 +984,19 @@ unsafe fn dtoa(value: f64, mut buffer: *mut u8) -> *mut u8 {
         *buffer = b'e';
         buffer = buffer.add(1);
     }
-    unsafe {
-        *buffer = b'+' + u8::from(dec_exp < 0) * (b'-' - b'+');
-        buffer = buffer.add(1);
-    }
+    let sign_ptr = buffer;
+    let sign = b'+' + u8::from(dec_exp < 0) * (b'-' - b'+');
     let mask = dec_exp >> 31;
     dec_exp = (dec_exp + mask) ^ mask; // absolute value
+    unsafe {
+        buffer = buffer.add(usize::from(dec_exp >= 10));
+    }
     let (a, bb) = divmod100(dec_exp.cast_unsigned());
     unsafe {
         *buffer = b'0' + a as u8;
         buffer = buffer.add(usize::from(dec_exp >= 100));
         buffer.cast::<u16>().write_unaligned(*digits2(bb as usize));
+        *sign_ptr = sign;
         buffer.add(2)
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ fn normal() {
 
 #[test]
 fn small_int() {
-    assert_eq!(dtoa(1.0), "1e+00");
+    assert_eq!(dtoa(1.0), "1e+0");
 }
 
 #[test]


### PR DESCRIPTION
`2.99e-9` vs `2.99e-09`