### PR TITLE
feat: add feature for ECMAScript Infinity formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ opt-level = "1"
 rand = "0.9"
 ryu = "1"
 
+[features]
+# Use ECMAScript-style strings "Infinity" and "-Infinity" instead of "inf" and "-inf".
+ecmascript = []
+
 [target.'cfg(not(miri))'.dev-dependencies]
 criterion = { version = "0.8", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,13 @@ use no_panic::no_panic;
 
 const BUFFER_SIZE: usize = 24;
 const NAN: &str = "NaN";
+#[cfg(feature = "ecmascript")]
+const INFINITY: &str = "Infinity";
+#[cfg(feature = "ecmascript")]
+const NEG_INFINITY: &str = "-Infinity";
+#[cfg(not(feature = "ecmascript"))]
 const INFINITY: &str = "inf";
+#[cfg(not(feature = "ecmascript"))]
 const NEG_INFINITY: &str = "-inf";
 
 // A decimal floating-point number sig * pow(10, exp).

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -61,6 +61,9 @@ mod dtoa_test {
 
     #[test]
     fn inf() {
+        #[cfg(feature = "ecmascript")]
+        assert_eq!(dtoa(f64::INFINITY), "Infinity");
+        #[cfg(not(feature = "ecmascript"))]
         assert_eq!(dtoa(f64::INFINITY), "inf");
     }
 


### PR DESCRIPTION
Hello

I was wondering if you'd be open to adding an option for printing out the infinities in the ECMAScript specification's form, and figured the best way to ask would be by doing the (very simple) work.

I'm quite interested in taking this into use in my JS engine, and I'd love to avoid having to do a string equality check to replace the "inf" string :)